### PR TITLE
Configure git to use the https protocol instead of ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@
 
 FROM golang:latest
 
+RUN git config --global url."https://${GITHUB_OAUTH_TOKEN}@github.com/".insteadOf "git@github.com:"
+
 # Create the default data directory
 RUN go get github.com/kubicorn/kubicorn/...
 


### PR DESCRIPTION
I couldn't get the docker build to work locally because I don't have access to the kubicorn repository over SSH. Changing it to use https instead fixes this.